### PR TITLE
chore: rename compose files for clarity

### DIFF
--- a/.github/workflows/load-test.yml
+++ b/.github/workflows/load-test.yml
@@ -13,7 +13,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Start full stack
-        run: docker compose -f docker-compose.full.yml up -d --build
+        run: docker compose -f docker-compose.yml up -d --build
         env:
           GRAFANA_ADMIN_PASSWORD: ci-load-test
 
@@ -26,7 +26,7 @@ jobs:
             sleep 5
           done
           echo "GondorGates did not become healthy in time"
-          docker compose -f docker-compose.full.yml logs gondor-app
+          docker compose -f docker-compose.yml logs gondor-app
           exit 1
 
       - name: Run k6 load test
@@ -47,4 +47,4 @@ jobs:
 
       - name: Tear down stack
         if: always()
-        run: docker compose -f docker-compose.full.yml down --volumes
+        run: docker compose -f docker-compose.yml down --volumes

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -125,7 +125,7 @@ Key bug fixed: `startsWith("/api/order")` falsely matched `/api/orders`. Correct
 - Denied rate over time (spikes indicate abuse or misconfigured clients)
 
 **Delivered:**
-- Grafana and Prometheus services added to `docker-compose.full.yml`
+- Grafana and Prometheus services added to `docker-compose.yml`
 - Prometheus scrape job configured against GondorGates `/actuator/prometheus`
 - Dashboard auto-provisioned via `grafana/provisioning/` — no manual import required
 - Alert rule provisioned via `grafana/provisioning/alerting/gondor-alerts.yml` — fires a critical alert when `rate(gondor_redis_errors_total[1m]) > 0` (Redis fail-open triggered, all rate limits suspended)
@@ -153,7 +153,7 @@ Grafana (:3000)              ← anonymous viewer access, auto-provisioned dashb
 
 **Delivered:**
 - Multi-stage `Dockerfile` — Maven build layer cached separately from app layer; distroless Java 21 runtime image (no shell, reduced attack surface, ~200MB final image)
-- `docker-compose.full.yml` — single `docker compose up -d --build` starts all five services with health-check dependency ordering (Redis → gondor-app → Prometheus → Grafana)
+- `docker-compose.yml` — single `docker compose up -d --build` starts all five services with health-check dependency ordering (Redis → gondor-app → Prometheus → Grafana)
 - `BackendProxyHandler` — transparent WebClient proxy activated by `BACKEND_URL` env var; strips hop-by-hop headers, forwards method/path/query/body, streams response back. When `BACKEND_URL` is blank, filter falls through to `chain.filter()` unchanged (embedded mode)
 - k6 load test (`k6/load-test.js`) — two scenarios run concurrently:
   - **Correctness**: 20 VUs share one user ID against `/api/login`; `gondor_allowed ≤ 5` threshold proves the Lua atomic eval has no double-spend race condition under concurrent load

--- a/README.md
+++ b/README.md
@@ -82,13 +82,13 @@ USER   (5 req / 1 s)
 
 ## Running locally
 
-### 1. Start Redis
+### 1. Start infrastructure
 
 ```bash
-docker compose up -d
+docker compose -f docker-compose.infra.yml up -d
 ```
 
-This starts a Redis 7.2 container on port `6379` with AOF persistence and a health check.
+This starts Redis 7.2 (port `6379`), Prometheus (port `9091`), and Grafana (port `3000`) with AOF persistence and health checks. The app itself runs on the host in the next step.
 
 ### 2. Start GondorGates
 
@@ -201,6 +201,14 @@ gondorgates:
 ## Adding GondorGates to your stack
 
 GondorGates runs as a sidecar container in front of your API. No code changes are required in your service.
+
+The image is published to GitHub Container Registry on every merge to `main`:
+
+```bash
+docker pull ghcr.io/kartik199/gondorgates:latest
+```
+
+Each build also produces an immutable short-SHA tag (e.g. `ghcr.io/kartik199/gondorgates:af8f619`) for reproducible deployments. SHA tags are listed under [Packages](https://github.com/Kartik199/GondorGates/pkgs/container/gondorgates).
 
 ### Quick start
 
@@ -329,7 +337,7 @@ Each bucket hash contains two fields: `tokens` (current count) and `last_refill`
 The load test in `k6/load-test.js` runs three scenarios back to back. The baseline scenario is specifically designed to isolate GondorGates' overhead from the underlying Spring WebFlux stack cost.
 
 ```bash
-docker compose -f docker-compose.full.yml up -d
+docker compose -f docker-compose.yml up -d
 BASE_URL=http://localhost:8080 k6 run k6/load-test.js
 ```
 

--- a/docker-compose.infra.yml
+++ b/docker-compose.infra.yml
@@ -1,33 +1,4 @@
 services:
-  gondor-app:
-    build: .
-    container_name: gondor-app
-    ports:
-      - "8080:8080"
-    environment:
-      - SPRING_DATA_REDIS_HOST=gondor-redis
-      - SPRING_DATA_REDIS_PORT=6379
-      - BACKEND_URL=http://demo-backend:9090
-    networks:
-      - gondor-network
-    depends_on:
-      gondor-redis:
-        condition: service_healthy
-    healthcheck:
-      test: ["CMD", "wget", "--quiet", "--tries=1", "--spider", "http://localhost:8080/actuator/health"]
-      interval: 15s
-      timeout: 5s
-      retries: 10
-      start_period: 30s
-
-  demo-backend:
-    image: nginx:alpine
-    container_name: demo-backend
-    volumes:
-      - ./demo-backend.conf:/etc/nginx/conf.d/default.conf:ro
-    networks:
-      - gondor-network
-
   gondor-redis:
     image: redis:7.2-alpine
     container_name: gondor-redis
@@ -36,6 +7,11 @@ services:
     command: ["redis-server", "--appendonly", "yes", "--save", ""]
     volumes:
       - gondor_data:/data
+    deploy:
+      resources:
+        limits:
+          cpus: '1.0'
+          memory: 512M
     networks:
       - gondor-network
     healthcheck:
@@ -50,22 +26,17 @@ services:
     ports:
       - "9091:9090"
     volumes:
-      - ./prometheus.full.yml:/etc/prometheus/prometheus.yml:ro
+      - ./prometheus.yml:/etc/prometheus/prometheus.yml:ro
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
     networks:
       - gondor-network
-    depends_on:
-      gondor-app:
-        condition: service_healthy
     healthcheck:
       test: ["CMD", "wget", "--quiet", "--tries=1", "--spider", "http://localhost:9090/-/healthy"]
       interval: 10s
       timeout: 5s
       retries: 5
 
-  # WARNING: Anonymous viewer access is enabled below for local demo convenience.
-  # Anyone who can reach port 3000 can view all dashboards, including per-user bucket state.
-  # Before deploying to any non-local environment: set GF_AUTH_ANONYMOUS_ENABLED=false
-  # and set GRAFANA_ADMIN_PASSWORD to a strong value in your .env file.
   gondor-grafana:
     image: grafana/grafana:10.4.2
     container_name: gondor-grafana
@@ -73,7 +44,7 @@ services:
       - "3000:3000"
     environment:
       - GF_SECURITY_ADMIN_USER=admin
-      - GF_SECURITY_ADMIN_PASSWORD=${GRAFANA_ADMIN_PASSWORD:-changeme}
+      - GF_SECURITY_ADMIN_PASSWORD=${GRAFANA_ADMIN_PASSWORD}
       - GF_AUTH_ANONYMOUS_ENABLED=true
       - GF_AUTH_ANONYMOUS_ORG_ROLE=Viewer
     volumes:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,33 @@
 services:
+  gondor-app:
+    build: .
+    container_name: gondor-app
+    ports:
+      - "8080:8080"
+    environment:
+      - SPRING_DATA_REDIS_HOST=gondor-redis
+      - SPRING_DATA_REDIS_PORT=6379
+      - BACKEND_URL=http://demo-backend:9090
+    networks:
+      - gondor-network
+    depends_on:
+      gondor-redis:
+        condition: service_healthy
+    healthcheck:
+      test: ["CMD", "wget", "--quiet", "--tries=1", "--spider", "http://localhost:8080/actuator/health"]
+      interval: 15s
+      timeout: 5s
+      retries: 10
+      start_period: 30s
+
+  demo-backend:
+    image: nginx:alpine
+    container_name: demo-backend
+    volumes:
+      - ./demo-backend.conf:/etc/nginx/conf.d/default.conf:ro
+    networks:
+      - gondor-network
+
   gondor-redis:
     image: redis:7.2-alpine
     container_name: gondor-redis
@@ -7,11 +36,6 @@ services:
     command: ["redis-server", "--appendonly", "yes", "--save", ""]
     volumes:
       - gondor_data:/data
-    deploy:
-      resources:
-        limits:
-          cpus: '1.0'
-          memory: 512M
     networks:
       - gondor-network
     healthcheck:
@@ -26,17 +50,22 @@ services:
     ports:
       - "9091:9090"
     volumes:
-      - ./prometheus.yml:/etc/prometheus/prometheus.yml:ro
-    extra_hosts:
-      - "host.docker.internal:host-gateway"
+      - ./prometheus.full.yml:/etc/prometheus/prometheus.yml:ro
     networks:
       - gondor-network
+    depends_on:
+      gondor-app:
+        condition: service_healthy
     healthcheck:
       test: ["CMD", "wget", "--quiet", "--tries=1", "--spider", "http://localhost:9090/-/healthy"]
       interval: 10s
       timeout: 5s
       retries: 5
 
+  # WARNING: Anonymous viewer access is enabled below for local demo convenience.
+  # Anyone who can reach port 3000 can view all dashboards, including per-user bucket state.
+  # Before deploying to any non-local environment: set GF_AUTH_ANONYMOUS_ENABLED=false
+  # and set GRAFANA_ADMIN_PASSWORD to a strong value in your .env file.
   gondor-grafana:
     image: grafana/grafana:10.4.2
     container_name: gondor-grafana
@@ -44,7 +73,7 @@ services:
       - "3000:3000"
     environment:
       - GF_SECURITY_ADMIN_USER=admin
-      - GF_SECURITY_ADMIN_PASSWORD=${GRAFANA_ADMIN_PASSWORD}
+      - GF_SECURITY_ADMIN_PASSWORD=${GRAFANA_ADMIN_PASSWORD:-changeme}
       - GF_AUTH_ANONYMOUS_ENABLED=true
       - GF_AUTH_ANONYMOUS_ORG_ROLE=Viewer
     volumes:


### PR DESCRIPTION
## Summary
- `docker-compose.full.yml` → `docker-compose.yml` — full stack is now the default; `docker compose up -d` works without a `-f` flag
- `docker-compose.yml` → `docker-compose.infra.yml` — infra-only (Redis + Prometheus + Grafana) for local dev with the app running on the host via `mvnw`
- Fixes the **Running locally** section in README which previously relied on the implicit default picking up the infra-only file — now uses `-f docker-compose.infra.yml` explicitly to prevent a port 8080 conflict when both the container and `mvnw` are started
- Updates all references in `.github/workflows/load-test.yml`, `README.md`, and `ARCHITECTURE.md`
- Adds `docker pull ghcr.io/kartik199/gondorgates:latest` to the README with a note distinguishing `latest` from immutable SHA tags for pinned production deployments

## Test plan
- [x] `docker compose up -d --build` (no `-f`) starts the full stack cleanly
- [x] `docker compose -f docker-compose.infra.yml up -d` starts infra-only stack
- [x] No remaining references to `docker-compose.full.yml` in the repo
- [x] Load test workflow updated to use `docker-compose.yml`

🤖 Generated with [Claude Code](https://claude.com/claude-code)